### PR TITLE
feat: add GitHub Actions workflow for building and pushing Docker images

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -53,17 +53,11 @@ jobs:
       - name: Checkout workflow repository
         uses: actions/checkout@v4
 
-      - name: Checkout ${{ matrix.repo }}
+      - name: Checkout target repository
         uses: actions/checkout@v4
         with:
           repository: ${{ format('{0}/{1}', github.repository_owner, matrix.repo) }}
-          # Use the workflow's triggering ref so the checked-out service
-          # matches the event/PR branch or commit that triggered this run.
-          # For pull requests, `github.head_ref` contains the source branch name;
-          # for pushes/tags `github.ref` is used. This ensures matrix checkouts
-          # build the same commit/branch as the workflow trigger instead of
-          # always using the default branch (e.g. `main`).
-          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           path: ${{ matrix.path }}
 
       - name: Setup Node.js
@@ -83,24 +77,11 @@ jobs:
           cache: maven
           cache-dependency-path: ${{ matrix.path }}/pom.xml
 
-      - name: Maven dependency cache (fallback)
-        if: matrix.runtime == 'maven'
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: maven-${{ runner.os }}-${{ hashFiles(format('{0}/pom.xml', matrix.path)) }}
-          restore-keys: |
-            maven-${{ runner.os }}-
-
       - name: Install & test frontend
         if: matrix.runtime == 'node'
         working-directory: ${{ matrix.path }}
         run: |
           npm ci --legacy-peer-deps
-          # Run frontend tests and fail the job on test failures. If frontend
-          # tests are intentionally non-blocking, document the exception in
-          # the CI/CD runbook and add a clear inline comment here explaining
-          # why they may be skipped instead of failing the build.
           npm run test -- --watch=false
           npm run build
 


### PR DESCRIPTION
**Linked Task:** #10 

---

## 🧾 Summary
- Changes: Added ORISO-Kubernetes/.github/workflows/build-and-push.yml, a matrix-based GitHub Actions workflow that builds the frontend plus core Spring Boot services, runs lint/tests, and pushes tagged images to GHCR on main.

- Why: Addresses Issue #10 (“use GitHub Actions to build images”) by replacing ad-hoc local Docker builds with a reproducible CI pipeline and registry publishing so Kubernetes deployments can pull immutable tags.

---

## ✅ Checklist
- [ ] CI/CD pipeline tested successfully  
- [ ] `.env` and secrets validated (no hardcoded credentials)  
- [ ] Rollback plan documented and tested  
- [ ] Change window defined and approved  
- [x] Infra cost & security impact reviewed  
- [ ] Documentation and configs updated  

---

## 🧪 Validation Proof
Attach deployment logs, screenshots, or command outputs verifying success and rollback.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI workflow to build, test, and produce container images for multiple services in the mono-repo via a matrix-driven pipeline; adds runtime setup, caching for faster builds, conditional image publishing for protected branches, and automated test/build steps for consistent, reliable delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->