### PR TITLE
feat(security-03): add userservice ip privacy mode helm wiring

### DIFF
--- a/helm/charts/userservice/templates/configmap.yaml
+++ b/helm/charts/userservice/templates/configmap.yaml
@@ -25,6 +25,7 @@ data:
   MATRIX_MIGRATION_ENABLED: {{ .Values.matrix.migrationEnabled | quote }}
   MATRIX_ADMIN_USERNAME: {{ .Values.matrix.adminUsername | quote }}
   PRIVACY_NOTIFICATION_PREVIEW_MODE: {{ .Values.privacy.notificationPreviewMode | quote }}
+  PRIVACY_IP_MODE: {{ .Values.privacy.ipMode | quote }}
   
   # RabbitMQ Configuration - Use full Kubernetes DNS FQDN (required for managed clusters)
   SPRING_RABBITMQ_HOST: {{ .Values.rabbitmq.host | quote }}
@@ -111,6 +112,7 @@ data:
     matrix.adminUsername=${MATRIX_ADMIN_USERNAME:}
     matrix.adminPassword=${MATRIX_ADMIN_PASSWORD:}
     privacy.notificationPreviewMode=${PRIVACY_NOTIFICATION_PREVIEW_MODE:NONE}
+    privacy.ipMode=${PRIVACY_IP_MODE:STANDARD}
     
     # ---------------- RabbitMQ ----------------
     spring.rabbitmq.host={{ .Values.rabbitmq.host }}

--- a/helm/charts/userservice/values.yaml
+++ b/helm/charts/userservice/values.yaml
@@ -64,6 +64,7 @@ matrix:
 # Privacy / Notification Preview Policy
 privacy:
   notificationPreviewMode: "NONE"
+  ipMode: "STANDARD"
 
 # RabbitMQ Configuration - Full DNS FQDN for managed clusters
 rabbitmq:


### PR DESCRIPTION
## Summary
- add `privacy.ipMode` to userservice chart values (`STANDARD` default)
- expose `PRIVACY_IP_MODE` in userservice configmap for runtime configuration
- wire `privacy.ipMode` into generated userservice `application.properties`
- keep changes scoped to userservice chart only (no unrelated chart package diffs)

## Test plan
- [x] `helm lint` on userservice chart
- [x] `helm upgrade oriso-platform` applied successfully
- [x] userservice rollout successful after restart
- [x] verified configmap contains `PRIVACY_IP_MODE=STANDARD`
- [x] verified userservice pod env includes `PRIVACY_IP_MODE`


Made with [Cursor](https://cursor.com)