### PR TITLE
Add restricted-agency-admin realm role for agency admin creation.

### DIFF
--- a/helm/charts/keycloak/keycloak-resources/realm.json
+++ b/helm/charts/keycloak/keycloak-resources/realm.json
@@ -147,6 +147,15 @@
         "attributes": {}
       },
       {
+        "id": "58e130ad-8ba1-4c36-a31e-eeb4c4cea91b",
+        "name": "restricted-agency-admin",
+        "description": "Restricted agency admin role assigned during agency admin creation",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "online-beratung",
+        "attributes": {}
+      },
+      {
         "id": "02b23701-9fc0-43c4-8b87-d804787cc7f2",
         "name": "tenant-admin",
         "description": "",


### PR DESCRIPTION
UserService assigns this role when creating agency admins; without it Keycloak returns 500 on POST /useradmin/agencyadmins.

# Pull Request

**Click the `Preview` tab and select a PR template:**

- [Default / Generic](?expand=1&template=default.md)
- [Frontend](?expand=1&template=frontend.md)
- [Backend](?expand=1&template=backend.md)
- [Documentation](?expand=1&template=docs.md)
- [Bug Fix](?expand=1&template=bugfix.md)
- [DevOps / Infrastructure](?expand=1&template=devops.md)
- [Architecture / Refactor](?expand=1&template=architecture.md)
- [Hotfix](?expand=1&template=hotfix.md)

---

**⚠️ Please select a template above by clicking on one of the links.**

