### PR TITLE
Theme Builder preview: app origin for admin env + frame-ancestors on app ingress

### DIFF
--- a/helm/charts/admin/templates/deployment.yaml
+++ b/helm/charts/admin/templates/deployment.yaml
@@ -47,6 +47,13 @@ spec:
           value: "https://{{ .Values.global.domains.auth }}"
         - name: VITE_API_URL
           value: "https://{{ .Values.global.domains.api }}"
+        # End-user app origin for the Theme Builder's sandboxed iframe
+        # preview (generate-runtime-env.js exposes it as APP_URL; without
+        # it the admin falls back to the API origin and the preview 404s).
+        - name: REACT_APP_APP_URL
+          value: "https://{{ .Values.global.domains.app }}"
+        - name: VITE_APP_URL
+          value: "https://{{ .Values.global.domains.app }}"
         {{- end }}
         {{- end }}
         {{- if .Values.resources }}

--- a/ingress/13-frontend-ingress.yaml
+++ b/ingress/13-frontend-ingress.yaml
@@ -7,6 +7,11 @@ metadata:
     # SSL/TLS
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    # Theme Builder preview: only the admin panel may embed the app in
+    # an iframe (sandboxed preview); everyone else is blocked.
+    # Requires allow-snippet-annotations on the ingress controller.
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      add_header Content-Security-Policy "frame-ancestors 'self' https://admin.oriso-dev.site" always;
 spec:
   ingressClassName: nginx
   rules:


### PR DESCRIPTION
## What

Deploy-side configuration for the Theme Builder's sandboxed iframe preview ([ORISO-Admin#125](https://github.com/OpenResilienceInitiative/ORISO-Admin/pull/125), [ORISO-Frontend#136](https://github.com/OpenResilienceInitiative/ORISO-Frontend/pull/136)):

1. **Admin chart**: `REACT_APP_APP_URL` / `VITE_APP_URL` from `global.domains.app`. The admin's `generate-runtime-env.js` already passes `APP_URL` through to `env.js`; without the variable, `runtimeConfig.appBaseUrl` falls back to the **API origin** and the preview iframe loads `api.<domain>/theme-demo` → 404. Verified against the deployed admin `env.js`, which currently carries only `API_URL` and `MATRIX_URL`.
2. **App ingress**: `Content-Security-Policy: frame-ancestors 'self' https://admin.oriso-dev.site` — the app currently sends **no framing protection at all**; this allows exactly the admin embed and blocks everyone else.

## Notes for review

- The CSP uses a `configuration-snippet` annotation → requires `allow-snippet-annotations` on ingress-nginx. If the controller forbids snippets, the header should move into the frontend proxy instead (say the word and I'll move it).
- Values here target oriso-dev.site; prod values need the same two changes with the prod domains on the next release sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)