### PR TITLE
fix(livekit): configure LIVEKIT_URL for oriso.org production

### DIFF
--- a/helm/charts/frontend/templates/deployment.yaml
+++ b/helm/charts/frontend/templates/deployment.yaml
@@ -43,8 +43,13 @@ spec:
           value: "https://{{ .Values.global.domains.matrix }}"
         - name: REACT_APP_ELEMENT_CALL_URL
           value: "https://{{ .Values.global.domains.call }}"
+        - name: REACT_APP_ELEMENT_CALL_BASE_URL
+          value: "https://{{ .Values.global.domains.call }}"
+        # LiveKit signalling must be a websocket URL (wss://).
         - name: REACT_APP_LIVEKIT_URL
-          value: "https://{{ .Values.global.domains.livekit }}"
+          value: "wss://{{ .Values.global.domains.livekit }}"
+        - name: REACT_APP_LIVEKIT_WS_URL
+          value: "wss://{{ .Values.global.domains.livekit }}"
         - name: REACT_APP_KEYCLOAK_URL
           value: "https://{{ .Values.global.domains.auth }}"
         - name: VITE_API_URL

--- a/helm/charts/livekit/templates/token-service-deployment.yaml
+++ b/helm/charts/livekit/templates/token-service-deployment.yaml
@@ -23,6 +23,17 @@ spec:
         - name: http
           containerPort: {{ .Values.tokenService.service.targetPort }}
           protocol: TCP
+        env:
+        {{- range $key, $value := .Values.tokenService.env }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- if .Values.global }}
+        {{- if .Values.global.domains }}
+        - name: LIVEKIT_URL
+          value: "wss://{{ .Values.global.domains.livekit }}"
+        {{- end }}
+        {{- end }}
         {{- if .Values.resources }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}

--- a/helm/charts/livekit/values.yaml
+++ b/helm/charts/livekit/values.yaml
@@ -23,6 +23,11 @@ tokenService:
     pullPolicy: Never  # Use local image
   
   replicas: 1
+
+  # Returned in SFU JWT responses as { url, jwt } — must be the public
+  # LiveKit websocket host (wss://), not the JWT service path.
+  env:
+    LIVEKIT_URL: "wss://livekit.oriso-dev.site"
   
   service:
     type: ClusterIP

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -1,0 +1,34 @@
+# Production overrides (oriso.org)
+# Usage: helm upgrade ... -f helm/values.yaml -f helm/values-prod.yaml
+
+global:
+  domains:
+    api: "api.oriso.org"
+    app: "app.oriso.org"
+    admin: "admin.oriso.org"
+    auth: "auth.oriso.org"
+    matrix: "matrix.oriso.org"
+    element: "element.oriso.org"
+    call: "call.oriso.org"
+    livekit: "livekit.oriso.org"
+    health: "health.oriso.org"
+    status: "status.oriso.org"
+  keycloak:
+    externalUrl: "https://auth.oriso.org"
+    jwt:
+      issuerUri: "https://auth.oriso.org/realms/online-beratung"
+      jwkSetUri: "https://auth.oriso.org/realms/online-beratung/protocol/openid-connect/certs"
+  matrix:
+    serverName: "oriso.org"
+    externalUrl: "https://matrix.oriso.org"
+  cors:
+    allowedOrigins:
+      - "https://app.oriso.org"
+      - "https://admin.oriso.org"
+      - "https://api.oriso.org"
+      - "https://call.oriso.org"
+
+livekit:
+  tokenService:
+    env:
+      LIVEKIT_URL: "wss://livekit.oriso.org"

--- a/ingress/18-livekit-ingress.yaml
+++ b/ingress/18-livekit-ingress.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - host: livekit.oriso-dev.site
+  - host: livekit.oriso.org
     http:
       paths:
       # LiveKit JWT token service
@@ -33,7 +33,7 @@ spec:
               number: 7880
   tls:
   - hosts:
-    - livekit.oriso-dev.site
+    - livekit.oriso.org
     secretName: livekit-tls
 
 


### PR DESCRIPTION
Group calls failed because the token service JWT still pointed browsers at livekit.oriso.site.

- Inject LIVEKIT_URL from global.domains.livekit into token-service deployment
- Add helm/values-prod.yaml with oriso.org domain overrides
- Update livekit ingress host/TLS to livekit.oriso.org
- Expose canonical frontend env names (REACT_APP_ELEMENT_CALL_BASE_URL, REACT_APP_LIVEKIT_WS_URL) with wss:// for LiveKit

# Pull Request

**Click the `Preview` tab and select a PR template:**

- [Default / Generic](?expand=1&template=default.md)
- [Frontend](?expand=1&template=frontend.md)
- [Backend](?expand=1&template=backend.md)
- [Documentation](?expand=1&template=docs.md)
- [Bug Fix](?expand=1&template=bugfix.md)
- [DevOps / Infrastructure](?expand=1&template=devops.md)
- [Architecture / Refactor](?expand=1&template=architecture.md)
- [Hotfix](?expand=1&template=hotfix.md)

---

**⚠️ Please select a template above by clicking on one of the links.**

