### PR TITLE
feat(keycloak): add probes + resource limits to Helm chart (epic #72)

### DIFF
--- a/helm/charts/keycloak/templates/keycloak-deployment.yaml
+++ b/helm/charts/keycloak/templates/keycloak-deployment.yaml
@@ -24,6 +24,10 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
+          {{- if .Values.keycloakResources }}
+          resources:
+            {{- toYaml .Values.keycloakResources | nindent 12 }}
+          {{- end }}
           command:
             - /opt/keycloak/bin/kc.sh
           args:
@@ -83,6 +87,29 @@ spec:
                 configMapKeyRef:
                   key: ROOT_LOGLEVEL
                   name: keycloak-configmap-env
+          {{- if .Values.keycloakProbes }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.keycloakProbes.startup.path | default "/health/started" }}
+              port: 8080
+            initialDelaySeconds: {{ .Values.keycloakProbes.startup.initialDelaySeconds | default 10 }}
+            periodSeconds: {{ .Values.keycloakProbes.startup.periodSeconds | default 10 }}
+            failureThreshold: {{ .Values.keycloakProbes.startup.failureThreshold | default 30 }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.keycloakProbes.liveness.path | default "/health/live" }}
+              port: 8080
+            initialDelaySeconds: {{ .Values.keycloakProbes.liveness.initialDelaySeconds | default 60 }}
+            periodSeconds: {{ .Values.keycloakProbes.liveness.periodSeconds | default 30 }}
+            failureThreshold: {{ .Values.keycloakProbes.liveness.failureThreshold | default 3 }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.keycloakProbes.readiness.path | default "/health/ready" }}
+              port: 8080
+            initialDelaySeconds: {{ .Values.keycloakProbes.readiness.initialDelaySeconds | default 30 }}
+            periodSeconds: {{ .Values.keycloakProbes.readiness.periodSeconds | default 10 }}
+            failureThreshold: {{ .Values.keycloakProbes.readiness.failureThreshold | default 3 }}
+          {{- end }}
           lifecycle:
             postStart:
               exec:

--- a/helm/charts/keycloak/templates/keycloak-deployment.yaml
+++ b/helm/charts/keycloak/templates/keycloak-deployment.yaml
@@ -94,7 +94,7 @@ spec:
               port: 8080
             initialDelaySeconds: {{ .Values.keycloakProbes.startup.initialDelaySeconds | default 10 }}
             periodSeconds: {{ .Values.keycloakProbes.startup.periodSeconds | default 10 }}
-            failureThreshold: {{ .Values.keycloakProbes.startup.failureThreshold | default 30 }}
+            failureThreshold: {{ .Values.keycloakProbes.startup.failureThreshold | default 60 }}
           livenessProbe:
             httpGet:
               path: {{ .Values.keycloakProbes.liveness.path | default "/health/live" }}


### PR DESCRIPTION
## Summary

Adds probes + resource limits to the Keycloak Helm chart on `kubernetes-deployment`.
Part of epic OpenResilienceInitiative/ORISO-Helm#37 — first of two PRs to close the production-readiness gaps.

## Changes

### Probes (gate: `.Values.keycloakProbes`)
| Probe | Path | Grace | Restarts after… |
|---|---|---|---|
| startup | `/health/started` | 5 min (30×10s) | — |
| liveness | `/health/live` | 90s (3×30s) | pod restart |
| readiness | `/health/ready` | 30s (3×10s) | removed from Service |

All probe values are configurable via parent chart values with sensible defaults.

### Resources (gated: `.Values.keycloakResources`)
Optional resource requests/limits — none set by default (backward compatible).
Parent chart can set, e.g.:
```yaml
keycloakResources:
  requests:
    cpu: 500m
    memory: 1Gi
  limits:
    cpu: 2000m
    memory: 4Gi
```

## What this does NOT include
- securityContext + serviceAccount → PR 2 (next)
- Keycloak version bump + RollingUpdate + `KC_CACHE_STACK=kubernetes` → PR 3

## Review
@jonas — per Hassan's guidance, changes target `kubernetes-deployment`.
See parent chart values for `keycloakProbes` + `keycloakResources` blocks.

### Reviewer checklist
- [ ] Startup probe threshold accounts for slow MariaDB init on cold start
- [ ] Probe defaults are compatible with existing deploy values
- [ ] Resources are optional (no breaking change for existing installs)