### PR TITLE
US-M31 add UserService graceful shutdown lifecycle

### DIFF
--- a/helm/charts/userservice/templates/configmap.yaml
+++ b/helm/charts/userservice/templates/configmap.yaml
@@ -49,6 +49,8 @@ data:
   
   # Spring Profile
   SPRING_PROFILES_ACTIVE: {{ .Values.spring.profiles.active | quote }}
+  SERVER_SHUTDOWN: "graceful"
+  SPRING_LIFECYCLE_TIMEOUT_PER_SHUTDOWN_PHASE: "30s"
 
   # Feature Flags
   MULTITENANCY_ENABLED: {{ .Values.features.multitenancy.enabled | quote }}
@@ -79,6 +81,8 @@ data:
     server.host=http://oriso-platform-userservice.caritas.svc.cluster.local:8082
     app.base.url=http://oriso-platform-userservice.caritas.svc.cluster.local:8082
     {{- end }}
+    server.shutdown=graceful
+    spring.lifecycle.timeout-per-shutdown-phase=30s
     
     # Tomcat thread pool - Scaled for 5000 concurrent users
     server.tomcat.threads.max=1000

--- a/helm/charts/userservice/templates/deployment.yaml
+++ b/helm/charts/userservice/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
         {{- include "userservice.selectorLabels" . | nindent 8 }}
         tier: backend
     spec:
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       containers:
       - name: userservice
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -30,6 +31,10 @@ spec:
             name: {{ include "userservice.fullname" . }}-config
         - secretRef:
             name: {{ include "userservice.fullname" . }}-secrets
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "sleep {{ .Values.preStopSleepSeconds }}"]
         {{- if .Values.resources.requests }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}

--- a/helm/charts/userservice/values.yaml
+++ b/helm/charts/userservice/values.yaml
@@ -10,6 +10,8 @@ image:
 # Deployment Configuration
 replicas: 1
 namespace: caritas
+terminationGracePeriodSeconds: 35
+preStopSleepSeconds: 5
 
 resources:
   requests: {}


### PR DESCRIPTION
## Summary

Implements the Kubernetes deployment-side part of US-M31 for UserService.

- Added `terminationGracePeriodSeconds: 35` to the UserService pod spec.
- Added configurable `preStop` sleep hook:
  - `preStopSleepSeconds: 5`
- Exposed Spring graceful shutdown config through the UserService config map:
  - `SERVER_SHUTDOWN=graceful`
  - `SPRING_LIFECYCLE_TIMEOUT_PER_SHUTDOWN_PHASE=30s`
- Kept the embedded `application.properties` block in sync.

This PR is intended to work together with the UserService PR:
https://github.com/OpenResilienceInitiative/ORISO-UserService/pull/135

## Testing

- `git diff --check`
  - passed
- Static verification confirmed the chart contains:
  - `terminationGracePeriodSeconds`
  - `preStop`
  - graceful shutdown env vars

## Note

I could not run a full rolling-deploy E2E locally because that requires Kubernetes. I also could not run `helm template` locally because Helm is not installed in my environment. Final verification should be done after deployment with:

```bash
kubectl -n caritas describe pod <userservice-pod>
kubectl -n caritas exec <userservice-pod> -- printenv | grep -E "SERVER_SHUTDOWN|SPRING_LIFECYCLE"
kubectl -n caritas rollout restart deploy/<userservice-deployment>