### PR TITLE
Add UserService identity technical secret values

### DIFF
--- a/helm/templates/userservice/userservice-deployment.yaml
+++ b/helm/templates/userservice/userservice-deployment.yaml
@@ -161,6 +161,16 @@ spec:
                 secretKeyRef:
                   key: KEYCLOAKSERVICE_TECHNICAL_USERNAME
                   name: userservice-secret
+            - name: IDENTITY_TECHNICAL_USER_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  key: IDENTITY_TECHNICAL_USER_USERNAME
+                  name: userservice-secret
+            - name: IDENTITY_TECHNICAL_USER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: IDENTITY_TECHNICAL_USER_PASSWORD
+                  name: userservice-secret
             - name: KEYCLOAK_CONFIG_APP_CLIENTID
               valueFrom:
                 configMapKeyRef:

--- a/helm/templates/userservice/userservice-secret.yaml
+++ b/helm/templates/userservice/userservice-secret.yaml
@@ -15,6 +15,8 @@ data:
   KEYCLOAK_CONFIG_ADMIN_PASSWORD: {{ .Values.global.secrets.keycloakAdminPassword | b64enc | quote }} 
   KEYCLOAKSERVICE_TECHNICAL_USERNAME: {{ .Values.userService.keycloakTechnicalUsername | b64enc | quote }}
   KEYCLOAKSERVICE_TECHNICAL_PASSWORD: {{ .Values.userService.keycloakTechnicalPassword | b64enc | quote }}
+  IDENTITY_TECHNICAL_USER_USERNAME: {{ .Values.userService.identityTechnicalUserUsername | b64enc | quote }}
+  IDENTITY_TECHNICAL_USER_PASSWORD: {{ .Values.userService.identityTechnicalUserPassword | b64enc | quote }}
   ROCKET_SYSTEMUSER_USERNAME: {{ .Values.userService.rocketSystemuserUsername | b64enc | quote }}
   ROCKET_SYSTEMUSER_PASSWORD: {{ .Values.userService.rocketSystemuserPassword | b64enc | quote }}
   ROCKET_TECHNICAL_USERNAME: {{ .Values.userService.rocketTechnicalUsername | b64enc | quote }}


### PR DESCRIPTION
## Summary
- Add UserService identity technical user credentials to the Kubernetes userservice secret template.
- Wire IDENTITY_TECHNICAL_USER_USERNAME and IDENTITY_TECHNICAL_USER_PASSWORD into the UserService deployment from userservice-secret.

## Requirement
Kubernetes/deployment follow-up for US-M19: hardcoded default password technical for the UserService technical identity user.

## Verification
- git diff --check
- Manual review of userservice secret/deployment wiring.

## Deploy Note
Set userService.identityTechnicalUserUsername and userService.identityTechnicalUserPassword to the real rotated values before deploying UserService.
This PR is connecte to PR https://github.com/OpenResilienceInitiative/ORISO-UserService/pull/172