### PR TITLE
fix(service-health-exporter): correct OTLP metric exporter import; pin deps

### DIFF
--- a/helm/charts/service-health-exporter/templates/configmap.yaml
+++ b/helm/charts/service-health-exporter/templates/configmap.yaml
@@ -18,7 +18,7 @@ data:
     from opentelemetry import metrics
     from opentelemetry.sdk.metrics import MeterProvider
     from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
-    from opentelemetry.exporter.otlp.proto.http import OTLPMetricExporter
+    from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
     from opentelemetry.sdk.resources import Resource
 
     # Get configuration from environment
@@ -29,7 +29,7 @@ data:
 
     # Configure OTEL
     resource = Resource.create({"service.name": "caritas-health-monitor"})
-    exporter = OTLPHTTPMetricExporter(endpoint=OTEL_ENDPOINT)
+    exporter = OTLPMetricExporter(endpoint=OTEL_ENDPOINT)
     reader = PeriodicExportingMetricReader(exporter, export_interval_millis=CHECK_INTERVAL * 1000)
     provider = MeterProvider(resource=resource, metric_readers=[reader])
     metrics.set_meter_provider(provider)

--- a/helm/charts/service-health-exporter/templates/deployment.yaml
+++ b/helm/charts/service-health-exporter/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
         - |
-          pip install --no-cache-dir opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-http requests && python3 /app/service-health-exporter.py
+          pip install --no-cache-dir {{ .Values.pip.packages | trim | replace "\n" " " }} && python3 /app/service-health-exporter.py
         env:
         - name: OTEL_ENDPOINT
           value: {{ .Values.otel.endpoint | quote }}

--- a/helm/charts/service-health-exporter/values.yaml
+++ b/helm/charts/service-health-exporter/values.yaml
@@ -6,6 +6,18 @@ image:
   tag: "3.11-slim"
   pullPolicy: IfNotPresent
 
+# Python dependencies pip-installed at container start. Versions are PINNED on
+# purpose: the previous unpinned install pulled a newer OpenTelemetry whose OTLP
+# metric exporter moved out of `opentelemetry.exporter.otlp.proto.http`, which
+# crash-looped this pod. Bump deliberately and only together with the imports in
+# the ConfigMap script.
+pip:
+  packages: |
+    opentelemetry-api==1.43.0
+    opentelemetry-sdk==1.43.0
+    opentelemetry-exporter-otlp-proto-http==1.43.0
+    requests==2.34.2
+
 replicas: 1
 namespace: caritas
 


### PR DESCRIPTION
## Symptom

`oriso-platform-service-health-exporter` on PreDev has been in **CrashLoopBackOff** for 15+ days (~3900 restarts). Every container start crashes at:

```
ImportError: cannot import name 'OTLPMetricExporter'
from 'opentelemetry.exporter.otlp.proto.http'
  File "/app/service-health-exporter.py", line 12, in <module>
```

## Root cause

Two defects in the ConfigMap script (`helm/charts/service-health-exporter/templates/configmap.yaml`) that break on any recent OpenTelemetry release:

1. **Wrong import path** — the HTTP metric exporter is in `opentelemetry.exporter.otlp.proto.http.metric_exporter`, not the package root. The script imports it from the root → `ImportError` at import time (the crash).
2. **Undefined name** — the exporter is then built as `OTLPHTTPMetricExporter(...)`, a name that is never imported → `NameError` once the import is corrected.

Compounding it, the deployment `pip install`s OpenTelemetry **unpinned** at every boot, so a newer release (1.43.0) silently relocated the symbol and broke the import.

## Fix

- Import `OTLPMetricExporter` from `...proto.http.metric_exporter` and instantiate it under that name.
- **Pin** the pip dependencies via `values.pip.packages` so a future OpenTelemetry release can't re-break the import paths unnoticed.

## Verification (local, no cluster change)

In a throwaway venv on the pinned versions:
- the **old** import reproduces the exact pod `ImportError`;
- the **new** import resolves;
- the full OTEL init + meter/instrument creation runs clean (only an expected export timeout, since the in-cluster collector isn't reachable off-cluster).

## Deploy

Takes effect on the next `helm upgrade` of `oriso-platform` (rolls the ConfigMap + deployment). **This PR applies no cluster change** — a redeploy is required and is intentionally left for a confirmed, supervised step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)