### PR TITLE
Fix agency registration ingress rewrite

### DIFF
--- a/ingress/03-agencyservice-ingress.yaml
+++ b/ingress/03-agencyservice-ingress.yaml
@@ -38,7 +38,7 @@ metadata:
     nginx.ingress.kubernetes.io/cors-allow-origin: $http_origin
     nginx.ingress.kubernetes.io/cors-max-age: '86400'
     nginx.ingress.kubernetes.io/enable-cors: 'true'
-    nginx.ingress.kubernetes.io/rewrite-target: /agencies/$2
+    nginx.ingress.kubernetes.io/rewrite-target: /agencies$1$2
     nginx.ingress.kubernetes.io/use-regex: 'true'
     nginx.ingress.kubernetes.io/ssl-redirect: 'true'
   name: agencyservice-agencies-ingress
@@ -49,13 +49,6 @@ spec:
   - host: api.oriso-dev.site
     http:
       paths:
-      - backend:
-          service:
-            name: oriso-platform-agencyservice
-            port:
-              number: 8084
-        path: /service/agencies
-        pathType: Exact
       - backend:
           service:
             name: oriso-platform-agencyservice


### PR DESCRIPTION
## Summary

- remove the exact `/service/agencies` ingress path that bypassed the regex rewrite assumptions
- change the rewrite target to `/agencies$1$2` so the root lookup and nested paths are both preserved
- make the PreDev hotpatch used during the E2E run reviewable in source control

## Validation

- `ruby -e 'require "yaml"; YAML.load_stream(File.read("ingress/03-agencyservice-ingress.yaml")); puts "yaml-ok"'`
- `git diff --check`
- Live PreDev manifest inspected after hotpatch: rewrite target is `/agencies$1$2` and no exact `/service/agencies` path remains.
- PreDev registration lookup by topic and postcode reached AgencyService and returned the expected visible agency.

## Notes

`kubectl apply --dry-run=client` could not be used from this local machine because the current kube context failed API resource discovery. The manifest change was still YAML-parsed locally and validated against the live PreDev ingress shape.

Closes #86
