### PR TITLE
Configure UserService agency admin URL

### DIFF
--- a/helm/charts/userservice/templates/configmap.yaml
+++ b/helm/charts/userservice/templates/configmap.yaml
@@ -40,6 +40,7 @@ data:
   TENANT_SERVICE_API_URL: {{ .Values.services.tenantService.apiUrl | quote }}
   CONSULTING_TYPE_SERVICE_API_URL: {{ .Values.services.consultingTypeService.apiUrl | quote }}
   AGENCY_SERVICE_API_URL: {{ .Values.services.agencyService.apiUrl | quote }}
+  AGENCY_ADMIN_SERVICE_API_URL: {{ .Values.services.agencyAdminService.apiUrl | quote }}
   
   # SMTP Configuration
   SMTP_HOST: {{ .Values.smtp.host | quote }}
@@ -133,7 +134,7 @@ data:
     consulting.type.service.api.url={{ .Values.services.consultingTypeService.apiUrl }}
     agency.service.api.url={{ .Values.services.agencyService.apiUrl }}
     agency.service.api.get.agencies=${agency.service.api.url}/
-    agency.admin.service.api.url=${app.base.url}
+    agency.admin.service.api.url={{ .Values.services.agencyAdminService.apiUrl }}
     
     # ---------------- SMTP ----------------
     smtp.host={{ .Values.smtp.host }}
@@ -157,4 +158,3 @@ data:
     multitenancy.enabled={{ .Values.features.multitenancy.enabled }}
     feature.multitenancy.with.single.domain.enabled={{ .Values.features.multitenancy.withSingleDomain.enabled }}
     service.encryption.appkey={{ .Values.encryption.appKey }}
-

--- a/helm/charts/userservice/values.yaml
+++ b/helm/charts/userservice/values.yaml
@@ -94,6 +94,8 @@ services:
     apiUrl: "http://oriso-platform-consultingtypeservice.caritas.svc.cluster.local:8083"
   agencyService:
     apiUrl: "http://oriso-platform-agencyservice.caritas.svc.cluster.local:8084"
+  agencyAdminService:
+    apiUrl: "http://oriso-platform-agencyservice.caritas.svc.cluster.local:8084"
 
 # Spring Profile
 spring:
@@ -119,4 +121,3 @@ smtp:
   user: ""
   password: ""
   from: "ORISO <notifications@oriso-dev.site>"
-


### PR DESCRIPTION
## Summary

Fixes #88.

The UserService chart previously rendered `agency.admin.service.api.url=${app.base.url}` and did not expose `AGENCY_ADMIN_SERVICE_API_URL`. That makes UserService call itself for AgencyAdminService calls when the live ConfigMap is recreated from the chart.

This PR adds a dedicated `services.agencyAdminService.apiUrl` value, renders `AGENCY_ADMIN_SERVICE_API_URL`, and writes `agency.admin.service.api.url` to the internal AgencyService URL.

## Validation

- `helm lint helm/charts/userservice`
- `helm template oriso-platform helm/charts/userservice | rg -n "AGENCY_ADMIN_SERVICE_API_URL|agency.admin.service.api.url|AGENCY_SERVICE_API_URL"`
- `git diff --check`